### PR TITLE
feat(Kconfig): added kconfig to tune internal parameters

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1,0 +1,19 @@
+menu "BLUECHERRY Configuration"
+
+    config BLUECHERRY_AUTO_SYNC_SEC
+        int "Auto Sync Interval (seconds)"
+        default 10
+        range 1 3600
+        help
+            Set the interval in seconds for automatic synchronization when no messages are published.
+            Minimum is 1 second, maximum is 3600 seconds (1 hour).
+
+    config BLUECHERRY_MAX_PENDING_OUTGOING_MESSAGES
+        int "Max Pending Outgoing Messages"
+        default 32
+        range 1 1024
+        help
+            Configure the maximum number of pending outgoing messages.
+            This setting helps manage memory usage and message flow.
+
+endmenu

--- a/src/bluecherry.h
+++ b/src/bluecherry.h
@@ -212,19 +212,9 @@ typedef enum {
 } _bluecherry_event_type;
 
 /**
- * @brief The maximum number of pending outgoing messages.
- */
-static const UBaseType_t BLUECHERRY_MAX_PENDING_OUTGOING_MESSAGES = 32;
-
-/**
  * @brief The priority used for automatically syncing with BlueCherry.
  */
 static const UBaseType_t BLUECHERRY_SP = 10;
-
-/**
- * @brief The period in seconds between automatic BlueCherry syncs.
- */
-static const uint8_t BLUECHERRY_AUTO_SYNC_SECONDS = 10;
 
 /**
  * @brief The size of the BlueCherry CoAP header.


### PR DESCRIPTION
Kconfig defines the amount of seconds between automatic syncing if the publish queue is empty.
Also defines the maximum length of the publish queue - useful if manually syncing.
removed watchdog adding to main thread within library (this should be up to the application)